### PR TITLE
Support usage with scalajs-bundler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,16 +9,18 @@ version := "1.0"
 
 organization := "org.querki"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.3"
 
-crossScalaVersions := Seq("2.10.5", "2.11.8", "2.12.0")
+scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")
+
+crossScalaVersions := Seq("2.10.5", "2.11.11", "2.12.3")
 
 libraryDependencies ++= Seq(
   "org.querki" %%% "querki-jsext" % "0.8",
-  "org.scala-js" %%% "scalajs-dom" % "0.9.1"
+  "org.scala-js" %%% "scalajs-dom" % "0.9.3"
 )
 
-jsDependencies in Test += RuntimeDOM
+jsEnv in Test := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 homepage := Some(url("http://www.querki.net/"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.16

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/src/main/scala/org/querki/jquery/JQuery.scala
+++ b/src/main/scala/org/querki/jquery/JQuery.scala
@@ -1061,7 +1061,7 @@ trait JQuery extends js.Object {
  *  cases. Code should not assume it is an integer. Also, dimensions may be incorrect when the page
  *  is zoomed by the user; browsers do not expose an API to detect this condition."
  */
-@ScalaJSDefined
+@js.native
 trait JQueryPosition extends js.Object {
   val left:Double
   val top:Double

--- a/src/main/scala/org/querki/jquery/JQueryStatic.scala
+++ b/src/main/scala/org/querki/jquery/JQueryStatic.scala
@@ -2,12 +2,12 @@ package org.querki.jquery
 
 import scala.scalajs.js
 import js.{undefined, UndefOr, |}
-import js.annotation.JSName
+import js.annotation.{JSName, JSImport}
 import org.scalajs.dom
 import dom.Element
 
 @js.native
-@JSName("jQuery")
+@JSImport("jquery", JSImport.Namespace)
 object JQueryStatic extends js.Object {
   
   /**


### PR DESCRIPTION
At the moment I cannot use `jquery-facade` with `scalajs-bundler` as it needs to explicitly import the dependency. This PR should fix that

I also needed to update to scala.js 0.6.20 to make this work and updated sbt, scala and the build accordingly

An alternative would be to let users do this but that requires converting `JQueryStatic` to a trait like in https://github.com/scala-js/scala-js-jquery/blob/master/src/main/scala/org/scalajs/jquery/JQuery.scala#L147
