### PR TITLE
Fix reserved-word warnings on then

### DIFF
--- a/src/main/scala/org/querki/jquery/JQueryDeferred.scala
+++ b/src/main/scala/org/querki/jquery/JQueryDeferred.scala
@@ -35,8 +35,8 @@ trait JQueryPromise extends js.Object {
   /**
    * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
    */
-  def then(
-    doneFilter:js.Function1[js.Any, js.Any], 
+  def `then`(
+    doneFilter:js.Function1[js.Any, js.Any],
     failFilter:UndefOr[js.Function1[js.Any, js.Any]] = js.undefined,
     progressFilter:UndefOr[js.Function1[js.Any, js.Any]] = js.undefined):JQueryPromise = js.native
 }

--- a/src/main/scala/org/querki/jquery/JQueryXHR.scala
+++ b/src/main/scala/org/querki/jquery/JQueryXHR.scala
@@ -12,5 +12,5 @@ trait JQueryXHR extends XMLHttpRequest with JQueryDeferred {
   def done(handler:js.Function3[js.Any, String, JQueryXHR, Any]):JQueryXHR = js.native
   def fail(handler:js.Function3[JQueryXHR, String, String, Any]):JQueryXHR = js.native
   def overrideMimeType(): js.Dynamic = js.native
-  def then(doneCallback:js.Function3[js.Any, String, JQueryXHR, Any], failCallback:js.Function3[JQueryXHR, String, String, Any]):JQueryXHR = js.native
+  def `then`(doneCallback:js.Function3[js.Any, String, JQueryXHR, Any], failCallback:js.Function3[JQueryXHR, String, String, Any]):JQueryXHR = js.native
 }


### PR DESCRIPTION
[`then` is a reserved word from `Scala 2.10.0`](https://contributors.scala-lang.org/t/the-state-of-then/1638/30).

I think warnings should be resolved as much as possible, so important warnings like depercation are not overlooked.