### PR TITLE
fix JQuery.scrollTop() return type is Double

### DIFF
--- a/src/main/scala/org/querki/jquery/JQuery.scala
+++ b/src/main/scala/org/querki/jquery/JQuery.scala
@@ -868,7 +868,7 @@ trait JQuery extends js.Object {
    * Get the current vertical position of the scroll bar for the first element in the set of
    * matched elements or set the vertical position of the scroll bar for every matched element.
    */
-  def scrollTop():Int = js.native
+  def scrollTop():Double = js.native
   /**
    * Set the current vertical position of the scroll bar for each of the set of matched elements.
    * 


### PR DESCRIPTION
JQuery.scrollTop() will always return Integer unless you zoom your browser.
I reproduced the behaviour in Chrome 76.

console output:
```
scalajsenv.js:211 Uncaught
$c_sjsr_UndefinedBehaviorError {s$1: "An undefined behavior was detected: 4.44444465637207 is not an instance of java.lang.Integer"
```

I checked this fix locally.