### PR TITLE
Enable Scala.js 1.0 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "jQuery Facade"
 
 normalizedName := "jquery-facade"
 
-version := "1.3"
+version := "2.0"
 
 organization := "org.querki"
 
@@ -13,10 +13,10 @@ scalaVersion := "2.13.1"
 
 scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")
 
-crossScalaVersions := Seq("2.10.7", "2.11.11", "2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.12.10", "2.13.1")
 
 libraryDependencies ++= Seq(
-  "org.querki" %%% "querki-jsext" % "0.9",
+  "org.querki" %%% "querki-jsext" % "0.10",
   "org.scala-js" %%% "scalajs-dom" % "0.9.8"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.3.8

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,9 +1,16 @@
 // Gives support for Scala.js compilation
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+
+libraryDependencies ++= {
+  if(scalaJSVersion.startsWith("1.")) {
+    Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0" )
+  } else {
+    Nil
+  }
+}

--- a/src/main/scala/org/querki/jquery/JQuery.scala
+++ b/src/main/scala/org/querki/jquery/JQuery.scala
@@ -3,7 +3,7 @@ package org.querki.jquery
 import scala.scalajs.js
 import js.UndefOr
 import js.|
-import js.annotation.{JSName, ScalaJSDefined}
+import js.annotation.JSName
 
 import org.scalajs.dom
 import dom.Element


### PR DESCRIPTION

**Update:** AFAIK can be merged and published, since [jducoeur/jsext](https://github.com/jducoeur/jsext) has been released: https://search.maven.org/artifact/org.querki/querki-jsext_sjs1_2.13/0.10/jar

~~This is meant as a "work in progress" PR, because it needs a release of [jducoeur/jsext](https://github.com/jducoeur/jsext) (probably `0.10`, see also jducoeur/jsext#19) which does not exist yet. As soon as jsext ist released for Scala.js `1.0.x`, this could be merged.~~

#### Details
- Dropped support for Scala.js `2.10` and `2.11`
- Upgraded sbt to `1.3.8` and sbt plugins to their newest versions
- Removed @ScalaJSDefined annotation which is deprecated in sjs1
- Added sjs0.6 and sjs1.0 cross-build using `SCALAJS_VERSION` env-variable
- Bumped version to `2.0` because of breaking changes (e.g. discontinued Scala versions)

Fixes #24