### PR TITLE
Add Scala3 to the build config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,17 +9,17 @@ version := "2.0"
 
 organization := "org.querki"
 
-scalaVersion := "2.13.1"
+scalaVersion := "3.1.0"
 
-scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")
+ThisBuild / scalacOptions ++= Seq("-feature", "-deprecation")
 
-crossScalaVersions := Seq("2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.13.1", "2.12.10", "2.13.1")
 
 libraryDependencies ++= Seq(
   "org.querki" %%% "querki-jsext" % "0.10",
-  "org.scala-js" %%% "scalajs-dom" % "0.9.8"
+  "org.scala-js" %%% "scalajs-dom" % "2.0.0"
 )
 
-jsEnv in Test := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
+Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 publishTo := sonatypePublishToBundle.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Scala.js cross-build support
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.7.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/src/main/scala/org/querki/jquery/JQueryDeferred.scala
+++ b/src/main/scala/org/querki/jquery/JQueryDeferred.scala
@@ -35,7 +35,7 @@ trait JQueryPromise extends js.Object {
   /**
    * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
    */
-  def then(
+  def `then`(
     doneFilter:js.Function1[js.Any, js.Any], 
     failFilter:UndefOr[js.Function1[js.Any, js.Any]] = js.undefined,
     progressFilter:UndefOr[js.Function1[js.Any, js.Any]] = js.undefined):JQueryPromise = js.native

--- a/src/main/scala/org/querki/jquery/JQueryExtensions.scala
+++ b/src/main/scala/org/querki/jquery/JQueryExtensions.scala
@@ -42,7 +42,7 @@ class JQueryExtensions(jq:JQuery) {
    * around $.each(), but is typically easier to use.
    */
   def foreach(func:Element => Unit):JQuery = {
-    jq.each({ e:Element =>
+    jq.each({ (e:Element) =>
       func(e)
     }:js.ThisFunction0[Element, Any])
     jq

--- a/src/main/scala/org/querki/jquery/JQueryStatic.scala
+++ b/src/main/scala/org/querki/jquery/JQueryStatic.scala
@@ -34,7 +34,6 @@ object JQueryStatic extends js.Object {
    * Accepts a string containing a CSS selector which is then used to match a set of elements.
    */
   def apply(): JQuery = js.native
-  def apply(selector: ElementDesc): JQuery = js.native
   def apply(selector: String, context: Element | JQuery): JQuery = js.native
   
   /**
@@ -45,7 +44,7 @@ object JQueryStatic extends js.Object {
    */
   def apply(html:String, ownerDocument:dom.html.Document):JQuery = js.native
   def apply(html:String, attributes:js.Dictionary[js.Any]):JQuery = js.native
-  def apply(obj: js.Object): JQuery = js.native
+  def apply(obj: ElementDesc | js.Object): JQuery = js.native
   
   /**
    * Binds a function to be executed when the DOM has finished loading.

--- a/src/main/scala/org/querki/jquery/JQueryXHR.scala
+++ b/src/main/scala/org/querki/jquery/JQueryXHR.scala
@@ -12,5 +12,5 @@ trait JQueryXHR extends XMLHttpRequest with JQueryDeferred {
   def done(handler:js.Function3[js.Any, String, JQueryXHR, Any]):JQueryXHR = js.native
   def fail(handler:js.Function3[JQueryXHR, String, String, Any]):JQueryXHR = js.native
   def overrideMimeType(): js.Dynamic = js.native
-  def then(doneCallback:js.Function3[js.Any, String, JQueryXHR, Any], failCallback:js.Function3[JQueryXHR, String, String, Any]):JQueryXHR = js.native
+  def `then`(doneCallback:js.Function3[js.Any, String, JQueryXHR, Any], failCallback:js.Function3[JQueryXHR, String, String, Any]):JQueryXHR = js.native
 }

--- a/src/main/scala/org/querki/jquery/package.scala
+++ b/src/main/scala/org/querki/jquery/package.scala
@@ -19,7 +19,7 @@ package object jquery {
    */
   type JQEvt = JQueryEventObject
   
-  implicit def builder2DialogOptions(builder:JQueryEventObjectBuilder) = builder._result
+  implicit def builder2DialogOptions(builder:JQueryEventObjectBuilder): JQueryEventObject = builder._result
 
   implicit def jQuery2Ext(jq:JQuery):JQueryExtensions = new JQueryExtensions(jq)
   


### PR DESCRIPTION
I added scala-3 to the build config and fixed errors from deprecated syntax.

I considered adding an alias for `then` which did not require escaping, such as
`andThen`, but I decided to leave that for the package maintainer to decide.

I also had to combine together to JQuery constructors since they overlapped on the
`org.scalajs.dom.Element` case.  I wasn't sure how you wanted to handle that.

I also have an associated pull request on jsext.